### PR TITLE
use preact-compat, bundle size is down to 43kb!

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "immutable": "^3.8.1",
     "keymirror": "^0.1.1",
+    "preact": "^7.1.0",
+    "preact-compat": "^3.9.4",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "5.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,11 @@ const config = {
     modules: [
       resolve(__dirname, 'node_modules'),
       resolve(__dirname, 'src')
-    ]
+    ],
+    alias: {
+      'react': 'preact-compat/dist/preact-compat',
+      'react-dom': 'preact-compat/dist/preact-compat'
+    }
   },
   devtool: 'eval-source-map',
   performance: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,6 +2972,28 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.1.2"
 
+preact-compat@^3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.9.4.tgz#55a5d81de637edc18c449bee45804b74bef15b34"
+  dependencies:
+    preact-render-to-string "^3.2.1"
+    preact-transition-group "^1.1.0"
+    proptypes "^0.14.3"
+
+preact-render-to-string@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.3.0.tgz#e7cf3815fe590d8ddc21e57c996f5c5657ca57d5"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact-transition-group@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.0.tgz#97d0beff0790d721faecd2560c02cd30d5426f23"
+
+preact@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-7.1.0.tgz#119cf65963abff28038b2330601adde969990a8d"
+
 prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -2979,6 +3001,10 @@ prepend-http@^1.0.0:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
 
 private@^0.1.6:
   version "0.1.6"
@@ -2997,6 +3023,10 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+proptypes@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/proptypes/-/proptypes-0.14.3.tgz#948d47f0ef1b501e34d934e42b39d60d26a8bf9d"
 
 proxy-addr@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
after adding preact-compat we saved nearly 50% on the bundle, combined HTML and JS is just 45kb. i'll reopen in the future if it turns out vanilla `preact` is necessary

closes #7 