### PR TITLE
create a central source of authority for state objects

### DIFF
--- a/src/data/model/TestModel.js
+++ b/src/data/model/TestModel.js
@@ -1,0 +1,7 @@
+import { Record } from 'immutable';
+
+const TestModel = {
+  rootText: 'test'
+};
+
+export default Record(TestModel);

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,19 @@
 /* global window, document */
-import { browserHistory, Router } from 'react-router';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
 import React from 'react';
+import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';
+import { createStore } from 'redux';
+
+import { browserHistory, Router } from 'react-router';
+import { modelMap } from './lib/state';
 import Routes from './Routes';
 import { store, extras } from './lib/store';
 
 const initialState = window.__INITIAL_STATE__; // eslint-disable-line no-underscore-dangle
+// use our model map to initialize our immutable Records in our state
+Object.keys(initialState).forEach((k) => {
+  initialState[k] = new modelMap[k](initialState[k]);
+});
 const finalStore = createStore(store, initialState, extras);
 
 ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 /* global window, document */
+import { createStore } from 'redux';
 import React from 'react';
 import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux';
 
 import { browserHistory, Router } from 'react-router';
 import { modelMap } from './lib/state';

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -1,0 +1,21 @@
+import { Map, Record } from 'immutable';
+
+import TestModel from '../data/model/TestModel';
+import testReducer from '../reducers/testReducer';
+
+const StateContent = Record({ model: '', reducer: '' });
+
+// this map is the authoritative source of reducers and models,
+// allowing us to use Records as Redux state objects instead of
+// plain objects
+const stateContents = new Map({
+  test: new StateContent({ model: TestModel, reducer: testReducer })
+});
+
+const reducerMap = stateContents.map((v) => v.reducer).toJS();
+const modelMap = stateContents.map((v) => v.model).toJS();
+
+export {
+  modelMap,
+  reducerMap
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,7 @@
 import { combineReducers } from 'redux';
-import testReducer from './testReducer';
 
-const reducer = combineReducers({
-  test: testReducer
-});
+import { reducerMap } from '../lib/state';
+
+const reducer = combineReducers(reducerMap);
 
 export default reducer;

--- a/src/reducers/testReducer.js
+++ b/src/reducers/testReducer.js
@@ -1,14 +1,9 @@
-import { Record } from 'immutable';
-
-const DefaultState = Record({
-  rootText: 'test'
-});
+import DefaultState from '../data/model/TestModel';
 
 export default function testReducer(state = new DefaultState(), action) {
-  const reducerState = (typeof state === 'object' && !(state instanceof DefaultState) && new DefaultState().merge(state)) || state;
   switch (action.type) {
     case 'UPDATE_TEXT':
-      return reducerState.merge({ rootText: action.data });
-    default: return reducerState;
+      return state.merge({ rootText: action.data });
+    default: return state;
   }
 }


### PR DESCRIPTION
I think I like this model for importing initial model state a bit better. Still a little more abstract than I'd like it but this reduces the possibility of type mismatches, while still pushing the user into using Immutable state objects. 

closes #1 